### PR TITLE
Fix LICENSE so automatic license checkers recognize it as MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
-RPly 1.1.4 license
-Copyright © 2003-2015 Diego Nehab.
+MIT license
+Copyright © 2003-2015 Diego Nehab
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),


### PR DESCRIPTION
After this change, the license parser of github.com recognizes
this project to be MIT-licensed; before, it assumed that the project
has a custom license.
